### PR TITLE
Preventing panic Crash

### DIFF
--- a/internal/smi/smi.go
+++ b/internal/smi/smi.go
@@ -160,7 +160,8 @@ func (test *SmiTest) installConformanceTool() error {
 	}
 
 	actionConfig := &action.Configuration{}
-	if err := actionConfig.Init(kube.GetConfig(test.kubeConfigPath, "", namespace), namespace, os.Getenv("HELM_DRIVER"), nil); err != nil {
+	nopLogger := func(_ string, _ ...interface{}) {} //dummy logger for helm packages
+	if err := actionConfig.Init(kube.GetConfig(test.kubeConfigPath, "", namespace), namespace, os.Getenv("HELM_DRIVER"), nopLogger); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: dhruv0000 <patel.4@iitj.ac.in>

***Description***
Bug: The panic crash was because the logger passed in Helm packages was nil.
Solution: Sending a dummy logger, since we also handle logs in our package and the helm logs are nop.

