### PR TITLE
Formatting time response to RFC3339

### DIFF
--- a/internal/smi/smi.go
+++ b/internal/smi/smi.go
@@ -94,7 +94,7 @@ func (test *SmiTest) Run(labels, annotations map[string]string) (Response, error
 
 	response := Response{
 		Id:                test.id,
-		Date:              time.Now().String(),
+		Date:              time.Now().Format(time.RFC3339),
 		MeshName:          test.adaptorName,
 		MeshVersion:       test.adaptorVersion,
 		CasesPassed:       "0",


### PR DESCRIPTION
Signed-off-by: dhruv0000 <patel.4@iitj.ac.in>

UI uses momentJS which supports RFC3339 timestamp. Also the meshery performance test uses RFC3339 timestamp.