### PR TITLE
Add custom operations features

### DIFF
--- a/kuma/custom_operation.go
+++ b/kuma/custom_operation.go
@@ -1,0 +1,14 @@
+package kuma
+
+import "github.com/layer5io/meshery-adapter-library/status"
+
+func (kuma *Kuma) applyCustomOperation(namespace string, manifest string, isDel bool) (string, error) {
+	st := status.Starting
+
+	err := kuma.applyManifest(isDel, namespace, []byte(manifest))
+	if err != nil {
+		return st, ErrCustomOperation(err)
+	}
+
+	return status.Completed, nil
+}

--- a/kuma/error.go
+++ b/kuma/error.go
@@ -7,25 +7,26 @@ import (
 )
 
 var (
-	ErrInstallKumaCode    = "kuma_test_code"
-	ErrMeshConfigCode     = "kuma_test_code"
-	ErrFetchManifestCode  = "kuma_test_code"
-	ErrClientConfigCode   = "kuma_test_code"
-	ErrClientSetCode      = "kuma_test_code"
-	ErrStreamEventCode    = "kuma_test_code"
-	ErrSampleAppCode      = "kuma_test_code"
-	ErrGetKumactlCode     = "kuma_test_code"
-	ErrDownloadBinaryCode = "kuma_test_code"
-	ErrInstallBinaryCode  = "kuma_test_code"
-	ErrUntarCode          = "kuma_test_code"
-	ErrUntarDefaultCode   = "kuma_test_code"
-	ErrMoveBinaryCode     = "kuma_test_code"
+	ErrInstallKumaCode     = "kuma_test_code"
+	ErrMeshConfigCode      = "kuma_test_code"
+	ErrFetchManifestCode   = "kuma_test_code"
+	ErrClientConfigCode    = "kuma_test_code"
+	ErrClientSetCode       = "kuma_test_code"
+	ErrStreamEventCode     = "kuma_test_code"
+	ErrSampleAppCode       = "kuma_test_code"
+	ErrGetKumactlCode      = "kuma_test_code"
+	ErrDownloadBinaryCode  = "kuma_test_code"
+	ErrInstallBinaryCode   = "kuma_test_code"
+	ErrUntarCode           = "kuma_test_code"
+	ErrUntarDefaultCode    = "kuma_test_code"
+	ErrMoveBinaryCode      = "kuma_test_code"
+	ErrCustomOperationCode = "kuma_test_code"
 
 	ErrOpInvalid    = errors.NewDefault(errors.ErrOpInvalid, "Invalid operation")
 	ErrUntarDefault = errors.NewDefault(ErrUntarDefaultCode, "Error untaring operation default")
 )
 
-// ErrInstallMesh is the error for install mesh
+// ErrInstallKuma is the error for install mesh
 func ErrInstallKuma(err error) error {
 	return errors.NewDefault(ErrInstallKumaCode, fmt.Sprintf("Error with kuma operation: %s", err.Error()))
 }
@@ -35,7 +36,8 @@ func ErrMeshConfig(err error) error {
 	return errors.NewDefault(ErrMeshConfigCode, fmt.Sprintf("Error configuration mesh: %s", err.Error()))
 }
 
-// ErrPortForward is the error for mesh port forward
+// ErrFetchManifest is the error occured during the process
+// fetching manifest
 func ErrFetchManifest(err error, des string) error {
 	return errors.NewDefault(ErrFetchManifestCode, fmt.Sprintf("Error fetching mesh manifest: %s", des))
 }
@@ -45,7 +47,7 @@ func ErrClientConfig(err error) error {
 	return errors.NewDefault(ErrClientConfigCode, fmt.Sprintf("Error setting client config: %s", err.Error()))
 }
 
-// ErrPortForward is the error for setting clientset
+// ErrClientSet is the error for setting clientset
 func ErrClientSet(err error) error {
 	return errors.NewDefault(ErrClientSetCode, fmt.Sprintf("Error setting clientset: %s", err.Error()))
 }
@@ -83,4 +85,10 @@ func ErrInstallBinary(err error) error {
 // ErrMoveBinary is the error for streaming event
 func ErrMoveBinary(err error) error {
 	return errors.NewDefault(ErrMoveBinaryCode, fmt.Sprintf("Error with moving binary kumactl: %s", err.Error()))
+}
+
+// ErrCustomOperation is the error occured during the process of
+// applying custom operation
+func ErrCustomOperation(err error) error {
+	return errors.NewDefault(ErrCustomOperationCode, fmt.Sprintf("Error applying custom operation: %s", err.Error()))
 }

--- a/kuma/kuma.go
+++ b/kuma/kuma.go
@@ -88,6 +88,19 @@ func (kuma *Kuma) ApplyOperation(ctx context.Context, opReq adapter.OperationReq
 			ee.Details = ""
 			hh.StreamInfo(e)
 		}(kuma, e)
+	case common.CustomOperation:
+		go func(hh *Kuma, ee *adapter.Event) {
+			stat, err := hh.applyCustomOperation(opReq.Namespace, opReq.CustomBody, opReq.IsDeleteOperation)
+			if err != nil {
+				e.Summary = fmt.Sprintf("Error while %s custom operation", stat)
+				e.Details = err.Error()
+				hh.StreamErr(e, err)
+				return
+			}
+			ee.Summary = fmt.Sprintf("Manifest %s successfully", status.Deployed)
+			ee.Details = ""
+			hh.StreamInfo(e)
+		}(kuma, e)
 	default:
 		kuma.StreamErr(e, ErrOpInvalid)
 	}


### PR DESCRIPTION
**Description**
This PR adds custom operations feature to the kuma adapter.

Tests Done (Both inside and outside the container):
- [x] Install/Uninstall Kuma Service mesh (Works only within container as Kuma supports selective os and linux distros)
- [x] Apply custom operations (Both adding and removing)

Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>